### PR TITLE
Enable tag propagation

### DIFF
--- a/ecs-nextcloud.yml
+++ b/ecs-nextcloud.yml
@@ -627,6 +627,7 @@ Resources:
         TargetGroupArn: !Ref LoadBalancerTargetGroup
       SchedulingStrategy: REPLICA
       TaskDefinition: !Ref EcsTaskDefinition
+      PropagateTags: SERVICE
 
   ECSTaskRole:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
Tags are now propagated from the ECS Service to the tasks deployed the service. Hence, tags propagated through CloudFormation can now be used as user-defined cost-allocation tag within the cost explorer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
